### PR TITLE
Handle iframe access errors when setting theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -2809,7 +2809,17 @@ def apply_brand_theme() -> None:
     st.markdown(
         f"""
         <script>
-        const targetDoc = window.parent?.document || document;
+        let targetDoc = document;
+        try {{
+            if (window.parent && window.parent !== window) {{
+                const parentDoc = window.parent.document;
+                if (parentDoc) {{
+                    targetDoc = parentDoc;
+                }}
+            }}
+        }} catch (error) {{
+            targetDoc = document;
+        }}
         if (targetDoc?.documentElement) {{
             targetDoc.documentElement.setAttribute('data-theme', '{active_theme['slug']}');
         }}


### PR DESCRIPTION
## Summary
- wrap the brand theme script in a try/catch so cross-origin iframe access falls back to the local document
- keep the theme data attribute updates working when the app is embedded

## Testing
- streamlit run app.py --server.headless true --server.port 8501 --browser.gatherUsageStats false
- playwright embed smoke test

------
https://chatgpt.com/codex/tasks/task_e_68d96d3570bc83239adc1308c56b0e37